### PR TITLE
Documentation fix: The plugin is registered as "http_ext" instead of "http-ext"

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A generic [fluentd][1] output plugin for sending logs to an HTTP endpoint
 ## Configuration options
 
     <match *>
-      type http-ext
+      type http_ext
       endpoint_url    http://localhost.local/api/<data.id> # <data.id> refres to data.id in the record like {"data"=> {"id"=> 1, "name"=> "foo"}}
       http_method     put    # default: post
       serializer      json   # default: form


### PR DESCRIPTION
Hi.

When I tried to configure the plugin with sample configuration given in README.md, message `"Unknown output plugin 'http-ext"` came out.

Then I just figured out the plugin is registered with a different name from the doc.

Here's a patch for your reference.
Thanks for the great work. :)
