### PR TITLE
Add verify_ssl option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A generic [fluentd][1] output plugin for sending logs to an HTTP endpoint
       username        alice  # default: ''
       password        bobpop # default: '', secret: true
       use_ssl         true   # default: false
+      verify_ssl      false  # default: true
       <headers>
         HeaderExample1 header1
         HeaderExample2 header2

--- a/lib/fluent/plugin/out_http_ext.rb
+++ b/lib/fluent/plugin/out_http_ext.rb
@@ -41,6 +41,9 @@ class Fluent::HTTPOutput < Fluent::Output
   # true | false
   config_param :use_ssl, :bool, :default => false
 
+  # true | false
+  config_param :verify_ssl, :bool, :default => true
+
   # Simple rate limiting: ignore any records within `rate_limit_msec`
   # since the last one.
   config_param :rate_limit_msec, :integer, :default => 0
@@ -154,6 +157,9 @@ class Fluent::HTTPOutput < Fluent::Output
       if @use_ssl
         client.use_ssl = true
         client.ca_file = OpenSSL::X509::DEFAULT_CERT_FILE
+        unless @verify_ssl
+          client.verify_mode = OpenSSL::SSL::VERIFY_NONE
+        end
       end
       res = client.start {|http| http.request(req) }
     rescue => e # rescue all StandardErrors


### PR DESCRIPTION
SSL feature is useful.
It would be better to have an option to turn SSL verification off for some special environment.

In this patch, verification is turned on by default.
