### PR TITLE
add raise_on_http_failure option

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,16 @@ A generic [fluentd][1] output plugin for sending logs to an HTTP endpoint
 
     <match *>
       type http_ext
-      endpoint_url    http://localhost.local/api/<data.id> # <data.id> refres to data.id in the record like {"data"=> {"id"=> 1, "name"=> "foo"}}
-      http_method     put    # default: post
-      serializer      json   # default: form
-      rate_limit_msec 100    # default: 0 = no rate limiting
-      raise_on_error  false  # default: true
-      authentication  basic  # default: none
-      username        alice  # default: ''
-      password        bobpop # default: '', secret: true
-      use_ssl         true   # default: false
+      endpoint_url          http://localhost.local/api/<data.id> # <data.id> refres to data.id in the record like {"data"=> {"id"=> 1, "name"=> "foo"}}
+      http_method           put                                  # default: post
+      serializer            json                                 # default: form
+      rate_limit_msec       100                                  # default: 0 = no rate limiting
+      raise_on_error        false                                # default: true
+      raise_on_http_failure true                                 # default: false
+      authentication        basic                                # default: none
+      username              alice                                # default: ''
+      password              bobpop                               # default: '', secret: true
+      use_ssl               true                                 # default: false
       <headers>
         HeaderExample1 header1
         HeaderExample2 header2

--- a/lib/fluent/plugin/out_http_ext.rb
+++ b/lib/fluent/plugin/out_http_ext.rb
@@ -48,9 +48,12 @@ class Fluent::HTTPOutput < Fluent::Output
   # Raise errors that were rescued during HTTP requests?
   config_param :raise_on_error, :bool, :default => true
 
+  # Raise errors when HTTP response code was not successful.
+  config_param :raise_on_http_failure, :bool, :default => false
+
 
   # nil | 'none' | 'basic'
-  config_param :authentication, :string, :default => nil 
+  config_param :authentication, :string, :default => nil
   config_param :username, :string, :default => ''
   config_param :password, :string, :default => '', :secret => true
 
@@ -167,7 +170,9 @@ class Fluent::HTTPOutput < Fluent::Output
                         else
                            "res=nil"
                         end
-          $log.warn "failed to #{req.method} #{uri} (#{res_summary})"
+          warning = "failed to #{req.method} #{uri} (#{res_summary})"
+          $log.warn warning
+          raise warning if @raise_on_http_failure
        end #end unless
     end # end begin
   end # end send_request

--- a/test/plugin/test_out_http_ext.rb
+++ b/test/plugin/test_out_http_ext.rb
@@ -256,6 +256,17 @@ class HTTPOutputTest < HTTPOutputTestBase
     assert_equal 0, @requests
   end
 
+  def test_http_failure_is_not_raised_on_http_failure_true_and_status_201
+    @status = 201
+
+    d = create_driver CONFIG_RAISE_ON_HTTP_FAILURE
+    assert_nothing_raised do
+      d.emit({ 'field1' => 50 })
+    end
+
+    @status = 200
+  end
+
   def test_http_failure_is_raised_on_http_failure_true
     @status = 500
 


### PR DESCRIPTION
Using this option, we can raise errors unless HTTP response is successful(2xx).
