### PR TITLE
Add custom formatter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A generic [fluentd][1] output plugin for sending logs to an HTTP endpoint
       password              bobpop                               # default: '', secret: true
       use_ssl               true                                 # default: false
       verify_ssl            false                                # default: true
+      format                <formatter>                          # default: '', <formatter> is the name of your formatter plugin
       <headers>
         HeaderExample1 header1
         HeaderExample2 header2

--- a/lib/fluent/test/formatter_test.rb
+++ b/lib/fluent/test/formatter_test.rb
@@ -1,0 +1,21 @@
+require 'fluent/formatter'
+
+module Fluent
+  module TextFormatter
+    class TestFormatter < Formatter
+      Plugin.register_formatter('test_formatter', self)
+
+      def configure(conf)
+        super
+      end
+
+      def format(tag, time, record)
+        output = {
+          "wrapped" => true,
+          "record" => record
+        }
+        output
+      end
+    end
+  end
+end

--- a/test/plugin/test_out_http_ext.rb
+++ b/test/plugin/test_out_http_ext.rb
@@ -218,6 +218,12 @@ class HTTPOutputTest < HTTPOutputTestBase
     ignore_http_status_code 400..599
   ]
 
+  CONFIG_CUSTOM_FORMATTER = %[
+    endpoint_url http://127.0.0.1:#{TEST_LISTEN_PORT}/api/
+    serializer json
+    format test_formatter
+  ]
+
   def create_driver(conf=CONFIG, tag='test.metrics')
     Fluent::Test::OutputTestDriver.new(Fluent::HTTPOutput, tag).configure(conf)
   end
@@ -522,5 +528,16 @@ class HTTPOutputTest < HTTPOutputTestBase
   def test_array_extend
     assert_equal [].to_set, Set.new([])
     assert_equal [1, 2].to_set, Set.new([1, 2])
+  end
+
+  def test_custom_formatter
+    d = create_driver CONFIG_CUSTOM_FORMATTER
+    payload = {"field" => 1}
+    d.emit(payload)
+    d.run
+
+    record = @posts[0]
+    assert_equal record[:json]["wrapped"], true
+    assert_equal record[:json]["record"], payload
   end
 end


### PR DESCRIPTION
What this will do is you may be able to use `formatters` to alter the body of your request before sending it to your output increasing the flexibility of this plugin.

This will close #21.
